### PR TITLE
Middleware returns 503 response if any worker check fails

### DIFF
--- a/lib/middleware.coffee
+++ b/lib/middleware.coffee
@@ -37,6 +37,7 @@ resolver = (worker, resolve, reject) ->
 # Writes a health check response
 respondWithHealth = (req, res, results) ->
     data = health process
+    responseCode = 200
 
     if cluster.isMaster
         data.workers = []
@@ -44,10 +45,11 @@ respondWithHealth = (req, res, results) ->
         for result in results
             if result.isRejected()
                 data.workers.push status: 'DOWN'
+                responseCode = 503
             else
                 data.workers.push result.value().health
 
-    res.writeHead 200, 'Content-Type': 'application/json'
+    res.writeHead responseCode, 'Content-Type': 'application/json'
     res.end JSON.stringify data
 
 # Middleware for connect that responds with a health check


### PR DESCRIPTION
TODO: I'd like to improve the testability of health checks. The unit test I added is brittle and relies heavily upon the current implementation rather than the API.